### PR TITLE
Set culture to en-US fpr tests that use .ToString() on numbers

### DIFF
--- a/tests/Gjallarhorn.Tests/Memory.fs
+++ b/tests/Gjallarhorn.Tests/Memory.fs
@@ -7,6 +7,17 @@ open System
 open NUnit.Framework
 
 module Memory =
+    let mutable culture : System.Globalization.CultureInfo = null
+
+    [<SetUp>]
+    let setup () =
+        culture <- System.Threading.Thread.CurrentThread.CurrentCulture
+        System.Threading.Thread.CurrentThread.CurrentCulture <- System.Globalization.CultureInfo.InvariantCulture
+
+    [<TearDown>]
+    let teardown () =
+        System.Threading.Thread.CurrentThread.CurrentCulture <- culture
+
     [<Test>]
     let ``Mutable\create doesn't cause tracking`` () =
         let value = Mutable.create 42

--- a/tests/Gjallarhorn.Tests/Signal.fs
+++ b/tests/Gjallarhorn.Tests/Signal.fs
@@ -6,6 +6,17 @@ open Gjallarhorn
 open System
 open NUnit.Framework
 
+let mutable culture : System.Globalization.CultureInfo = null
+
+[<SetUp>]
+let setup () =
+    culture <- System.Threading.Thread.CurrentThread.CurrentCulture
+    System.Threading.Thread.CurrentThread.CurrentCulture <- System.Globalization.CultureInfo.InvariantCulture
+
+[<TearDown>]
+let teardown () =
+    System.Threading.Thread.CurrentThread.CurrentCulture <- culture
+
 [<Test;TestCaseSource(typeof<Utilities>,"CasesStart")>]
 let ``Signal\constant constructs with proper value`` start =
     let value = Signal.constant start


### PR DESCRIPTION
The tests that compare string representations of numbers run `.ToString()` with the default culture, while the hardcoded values in `Utilities.fs` are in the American format, which causes the tests to fail in other cultures. I have added setup and teardown functions to those test modules to force them to be run with an en-US culture.