### PR TITLE
Fix FsXaml DLL paths in example project

### DIFF
--- a/samples/ElmInspiredOne/Wpf/WpfElmInspiredOne.fsproj
+++ b/samples/ElmInspiredOne/Wpf/WpfElmInspiredOne.fsproj
@@ -40,10 +40,10 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="FsXaml.Wpf">
-      <HintPath>..\..\packages\build\FsXaml.Wpf\lib\net45\FsXaml.Wpf.dll</HintPath>
+      <HintPath>..\..\..\packages\build\FsXaml.Wpf\lib\net45\FsXaml.Wpf.dll</HintPath>
     </Reference>
     <Reference Include="FsXaml.Wpf.TypeProvider">
-      <HintPath>..\..\packages\build\FsXaml.Wpf\lib\net45\FsXaml.Wpf.TypeProvider.dll</HintPath>
+      <HintPath>..\..\..\packages\build\FsXaml.Wpf\lib\net45\FsXaml.Wpf.TypeProvider.dll</HintPath>
     </Reference>
     <Reference Include="mscorlib" />
     <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">


### PR DESCRIPTION
This project didn't build, because the relative paths to the FsXaml DLLs were off by one directory level.