### PR TITLE
Paket templates. Fix #25.

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -87,7 +87,9 @@ Target "AssemblyInfo" (fun _ ->
           Attribute.Product project
           Attribute.Description summary
           Attribute.Version release.AssemblyVersion
-          Attribute.FileVersion release.AssemblyVersion ]
+          Attribute.FileVersion release.AssemblyVersion
+          Attribute.Copyright "Copyright 2016 Reed Copsey, Jr."
+          Attribute.Company "Reed Copsey, Jr." ]
 
     let getProjectDetails projectPath =
         let projectName = System.IO.Path.GetFileNameWithoutExtension(projectPath)

--- a/src/Gjallarhorn.Bindable.Wpf/AssemblyInfo.fs
+++ b/src/Gjallarhorn.Bindable.Wpf/AssemblyInfo.fs
@@ -6,8 +6,8 @@ open System.Reflection
 [<assembly: AssemblyDescriptionAttribute("Framework for managing mutable data with change notification and live views")>]
 [<assembly: AssemblyVersionAttribute("0.0.5")>]
 [<assembly: AssemblyFileVersionAttribute("0.0.5")>]
+[<assembly: AssemblyCopyrightAttribute("Copyright 2016 Reed Copsey, Jr.")>]
 [<assembly: AssemblyCompanyAttribute("Reed Copsey, Jr.")>]
-[<assembly: AssemblyCopyright("Copyright 2016 Reed Copsey, Jr.")>]
 do ()
 
 module internal AssemblyVersionInformation =

--- a/src/Gjallarhorn.Bindable.Wpf/AssemblyInfo.fs
+++ b/src/Gjallarhorn.Bindable.Wpf/AssemblyInfo.fs
@@ -6,6 +6,8 @@ open System.Reflection
 [<assembly: AssemblyDescriptionAttribute("Framework for managing mutable data with change notification and live views")>]
 [<assembly: AssemblyVersionAttribute("0.0.5")>]
 [<assembly: AssemblyFileVersionAttribute("0.0.5")>]
+[<assembly: AssemblyCompanyAttribute("Reed Copsey, Jr.")>]
+[<assembly: AssemblyCopyright("Copyright 2016 Reed Copsey, Jr.")>]
 do ()
 
 module internal AssemblyVersionInformation =

--- a/src/Gjallarhorn.Bindable.Wpf/paket.template
+++ b/src/Gjallarhorn.Bindable.Wpf/paket.template
@@ -1,5 +1,5 @@
 ﻿type project
-tags wpf
+tags F# FSharp async Reactive Rx Observable WPF
 projectUrl https://github.com/ReedCopsey/Gjallarhorn
 licenseUrl http://opensource.org/licenses/MIT
 

--- a/src/Gjallarhorn.Bindable.Wpf/paket.template
+++ b/src/Gjallarhorn.Bindable.Wpf/paket.template
@@ -3,3 +3,11 @@ tags wpf
 projectUrl https://github.com/ReedCopsey/Gjallarhorn
 licenseUrl http://opensource.org/licenses/MIT
 
+frameworkAssemblies
+  PresentationCore
+  PresentationFramework
+  System.Xml
+  System.Xaml
+  WindowsBase
+  UIAutomationTypes
+

--- a/src/Gjallarhorn.Bindable.Wpf/paket.template
+++ b/src/Gjallarhorn.Bindable.Wpf/paket.template
@@ -1,0 +1,5 @@
+﻿type project
+tags wpf
+projectUrl https://github.com/ReedCopsey/Gjallarhorn
+licenseUrl http://opensource.org/licenses/MIT
+

--- a/src/Gjallarhorn.Bindable/AssemblyInfo.fs
+++ b/src/Gjallarhorn.Bindable/AssemblyInfo.fs
@@ -6,8 +6,8 @@ open System.Reflection
 [<assembly: AssemblyDescriptionAttribute("Framework for managing mutable data with change notification and live views")>]
 [<assembly: AssemblyVersionAttribute("0.0.5")>]
 [<assembly: AssemblyFileVersionAttribute("0.0.5")>]
+[<assembly: AssemblyCopyrightAttribute("Copyright 2016 Reed Copsey, Jr.")>]
 [<assembly: AssemblyCompanyAttribute("Reed Copsey, Jr.")>]
-[<assembly: AssemblyCopyright("Copyright 2016 Reed Copsey, Jr.")>]
 do ()
 
 module internal AssemblyVersionInformation =

--- a/src/Gjallarhorn.Bindable/AssemblyInfo.fs
+++ b/src/Gjallarhorn.Bindable/AssemblyInfo.fs
@@ -6,6 +6,8 @@ open System.Reflection
 [<assembly: AssemblyDescriptionAttribute("Framework for managing mutable data with change notification and live views")>]
 [<assembly: AssemblyVersionAttribute("0.0.5")>]
 [<assembly: AssemblyFileVersionAttribute("0.0.5")>]
+[<assembly: AssemblyCompanyAttribute("Reed Copsey, Jr.")>]
+[<assembly: AssemblyCopyright("Copyright 2016 Reed Copsey, Jr.")>]
 do ()
 
 module internal AssemblyVersionInformation =

--- a/src/Gjallarhorn.Bindable/paket.template
+++ b/src/Gjallarhorn.Bindable/paket.template
@@ -1,0 +1,5 @@
+﻿type project
+tags wpf
+projectUrl https://github.com/ReedCopsey/Gjallarhorn
+licenseUrl http://opensource.org/licenses/MIT
+

--- a/src/Gjallarhorn.Bindable/paket.template
+++ b/src/Gjallarhorn.Bindable/paket.template
@@ -1,5 +1,5 @@
 ﻿type project
-tags wpf
+tags F# FSharp async Reactive Rx Observable
 projectUrl https://github.com/ReedCopsey/Gjallarhorn
 licenseUrl http://opensource.org/licenses/MIT
 

--- a/src/Gjallarhorn/AssemblyInfo.fs
+++ b/src/Gjallarhorn/AssemblyInfo.fs
@@ -6,8 +6,8 @@ open System.Reflection
 [<assembly: AssemblyDescriptionAttribute("Framework for managing mutable data with change notification and live views")>]
 [<assembly: AssemblyVersionAttribute("0.0.5")>]
 [<assembly: AssemblyFileVersionAttribute("0.0.5")>]
+[<assembly: AssemblyCopyrightAttribute("Copyright 2016 Reed Copsey, Jr.")>]
 [<assembly: AssemblyCompanyAttribute("Reed Copsey, Jr.")>]
-[<assembly: AssemblyCopyright("Copyright 2016 Reed Copsey, Jr.")>]
 do ()
 
 module internal AssemblyVersionInformation =

--- a/src/Gjallarhorn/AssemblyInfo.fs
+++ b/src/Gjallarhorn/AssemblyInfo.fs
@@ -6,6 +6,8 @@ open System.Reflection
 [<assembly: AssemblyDescriptionAttribute("Framework for managing mutable data with change notification and live views")>]
 [<assembly: AssemblyVersionAttribute("0.0.5")>]
 [<assembly: AssemblyFileVersionAttribute("0.0.5")>]
+[<assembly: AssemblyCompanyAttribute("Reed Copsey, Jr.")>]
+[<assembly: AssemblyCopyright("Copyright 2016 Reed Copsey, Jr.")>]
 do ()
 
 module internal AssemblyVersionInformation =

--- a/src/Gjallarhorn/paket.template
+++ b/src/Gjallarhorn/paket.template
@@ -1,0 +1,5 @@
+﻿type project
+tags wpf
+projectUrl https://github.com/ReedCopsey/Gjallarhorn
+licenseUrl http://opensource.org/licenses/MIT
+

--- a/src/Gjallarhorn/paket.template
+++ b/src/Gjallarhorn/paket.template
@@ -1,5 +1,5 @@
 ﻿type project
-tags wpf
+tags F# FSharp async Reactive Rx Observable
 projectUrl https://github.com/ReedCopsey/Gjallarhorn
 licenseUrl http://opensource.org/licenses/MIT
 


### PR DESCRIPTION
Usage:
> .paket/paket.exe pack output publish
Packages are in $(slndir)/publish