### PR TITLE
Make Func's explict about the generic type they accept. 

### DIFF
--- a/src/Gjallarhorn.Bindable/BindingSource.fs
+++ b/src/Gjallarhorn.Bindable/BindingSource.fs
@@ -101,15 +101,15 @@ type BindingSource() as self =
         |> Signal.Subscription.create (fun result -> updateErrors name result)
         |> this.AddDisposable
 
-        this.AddReadOnlyProperty (getErrorsPropertyName name, fun _ -> validator.Value.ToList(true) )
-        this.AddReadOnlyProperty (getValidPropertyName name,fun _ -> validator.Value.IsValidResult )
+        this.AddReadOnlyProperty (getErrorsPropertyName name, Func<Collections.Generic.List<string>>(fun _ -> validator.Value.ToList(true) ))
+        this.AddReadOnlyProperty (getValidPropertyName name, Func<bool>(fun _ -> validator.Value.IsValidResult ))
 
         updateErrors name validator.Value 
 
     /// Track an Input type
     member this.TrackInput (name, input : Report<'a,'b>) =
         this.TrackObservable (name, input.UpdateStream)
-        this.AddReadOnlyProperty (name, Func<_>(input.GetValue))
+        this.AddReadOnlyProperty (name, Func<'b>(input.GetValue))
         
         // If we're validated input, handle adding our validation information as well
         match input with
@@ -134,7 +134,7 @@ type BindingSource() as self =
     member this.TrackComponent<'a,'b> (name, comp : Component<'a,'b>, model : ISignal<'a>) = 
         let source = this.CreateObservableBindingSource<'b>()
         this.TrackObservable (name, model)
-        this.AddReadOnlyProperty(name, fun _ -> source)
+        this.AddReadOnlyProperty(name, Func<ObservableBindingSource<'b>>(fun _ -> source))
         
         let obs = comp (source :> BindingSource) model
         source.OutputObservables(obs)
@@ -143,7 +143,7 @@ type BindingSource() as self =
 
     /// Add a readonly binding source for a constant value with a given name    
     member this.ConstantToView (value, name) = 
-        this.AddReadOnlyProperty(name, fun _ -> value)
+        this.AddReadOnlyProperty(name, Func<'b>(fun () -> value))
 
     /// Filter a signal to only output when we're valid
     member this.FilterValid signal =

--- a/src/Gjallarhorn/Dependencies.fs
+++ b/src/Gjallarhorn/Dependencies.fs
@@ -86,7 +86,7 @@ type internal DependencyTracker<'a>(dependsOn : WeakReference<ITracksDependents>
     // Do our signal, but also remove any unneeded dependencies while we're at it
     let signalAndUpdateDependencies (source : ISignal<'a>) =
         // We want this to be lazy so we don't evaluate the value unless we actually have observers
-        let v = Lazy<_>(fun _ -> source.Value)
+        let v = Lazy<'a>(fun () -> source.Value)
 
         depIDeps <- depIDeps |> Array.filter signalIfAliveDep
         depObservers <- depObservers |> Array.filter (signalIfAliveObs v)


### PR DESCRIPTION
This is to fix a bug on mobile that threw an Invalid IL exception.

Is master the best branch for this to be merged into? 

I have tested this on the simulator for iOS.I have not yet tested this on Android (will confirm this soon).
Testing still to be done:
- test on latest version of mono for iOS and Android released by Xamarin
- test on latest version of FSharp (4.1)
- test this doesn't break anything related to WPF and windows

There are no unit (or other) tests on here. I could add a UI test (Android only since windows users won't be able to run iOS) if that is desired to prevent this bug from popping up again. 