### PR TITLE
Remove as selfs

### DIFF
--- a/src/Gjallarhorn/CoreTypes.fs
+++ b/src/Gjallarhorn/CoreTypes.fs
@@ -217,7 +217,7 @@ type SignalBase<'a> private (dependencies:IDependencyManager<'a>) =
             GC.SuppressFinalize this
 
 /// Type to wrap in observable into a signal.
-type internal ObservableToSignal<'a when 'a : equality>(valueProvider : IObservable<'a>, initialValue:'a, dummy:unit) =
+type internal ObservableToSignal<'a when 'a : equality> private (valueProvider : IObservable<'a>, initialValue:'a, dummy:unit) =
     let mutable lastValue = initialValue
 
     // Wrap this in an option so we can stop referencing it on disposal
@@ -477,7 +477,7 @@ type internal ChooseSignal<'a,'b when 'b : equality>(valueProvider : ISignal<'a>
     override this.OnDisposing () =
         DisposeHelpers.cleanup &valueProvider false this
 
-type internal CachedSignal<'a when 'a : equality> (valueProvider : ISignal<'a>, dummy:unit) =
+type internal CachedSignal<'a when 'a : equality> private (valueProvider : ISignal<'a>, dummy:unit) =
     inherit SignalBase<'a>([| valueProvider |])
 
     let mutable lastValue = valueProvider.Value

--- a/src/Gjallarhorn/IO.fs
+++ b/src/Gjallarhorn/IO.fs
@@ -24,19 +24,19 @@ type Report<'a,'b when 'a : equality and 'b : equality> (input : ISignal<'a>, co
     member __.GetValue () = source.Value
 
 /// Used to report data to a user with validation
-type ValidatedReport<'a, 'b when 'a : equality and 'b : equality> (input : ISignal<'a>, conversion : 'a -> 'b) as self =
+type ValidatedReport<'a, 'b when 'a : equality and 'b : equality> private (input : ISignal<'a>, conversion : 'a -> 'b) =
     inherit Report<'a, 'b>(input, conversion)
     
     /// The validation results as a signal
     member val private ValidationInternal = (ValueNone:IValidatedSignal<'b,'b> voption) with get, set
     member this.Validation = this.ValidationInternal
-        new(input : ISignal<'a>, conversion : 'a -> 'b, validation : Validation<'b, 'b>) as this =
-            ValidatedReport<'a,'b>(input, conversion)
-            then
-                this.ValidationInternal <-
-                    this.UpdateStream
-                    |> Signal.validate validation
-                    |> ValueSome
+    new(input : ISignal<'a>, conversion : 'a -> 'b, validation : Validation<'b, 'b>) as this =
+        ValidatedReport<'a,'b>(input, conversion)
+        then
+            this.ValidationInternal <-
+                this.UpdateStream
+                |> Signal.validate validation
+                |> ValueSome
 
 /// Used as an input and output mapping to report and fetch data from a user
 type InOut<'a, 'b when 'a : equality and 'b : equality> (input : ISignal<'a>, conversion : 'a -> 'b) =    
@@ -106,7 +106,7 @@ type ValidatedOut<'a, 'b when 'a : equality> private (initialValue : 'a) =
                 |> ValueSome
     
 /// Used as an input and output mapping which mutates an input IMutatable, with validation to report and fetch data from a user
-type MutatableInOut<'a,'b when 'a : equality and 'b : equality> (input : IMutatable<'a>, conversion : 'a -> 'b, validation : Validation<'b, 'a>, dummy:unit) =
+type MutatableInOut<'a,'b when 'a : equality and 'b : equality> private (input : IMutatable<'a>, conversion : 'a -> 'b, validation : Validation<'b, 'a>, dummy:unit) =
     inherit ValidatedInOut<'a,'b, 'a>(input, conversion, validation)
 
     member val private Subscription:IDisposable voption = ValueNone with get, set


### PR DESCRIPTION
`as self` is dangerous
The compiler puts in runtime initialization checks (see SharpLab) and these will throw if these checks fail.
This PR contains simple and unintelligent fixes for this using an additional constructor and the `then` keyword.

ValidatorMappingSignal is left with `as self` as refactoring that was getting complicated.
