### PR TITLE
Remove as selfs using Create methods

### DIFF
--- a/src/Gjallarhorn/CoreTypes.fs
+++ b/src/Gjallarhorn/CoreTypes.fs
@@ -137,7 +137,7 @@ type Mutable<'a when 'a : equality>(value : 'a) =
 /// Base class which simplifies implementation of standard signals
 /// Needs to be initialized by calling .InitDependencies
 type SignalBase<'a>() =
-
+    // A SignalBase should be initialized via .Init before any properties are called.
     let mutable dependencies:IDependencyManager<'a> = null
     let mutable dirty = false
 
@@ -219,6 +219,8 @@ type SignalBase<'a>() =
 
 /// Type to wrap in observable into a signal.
 type internal ObservableToSignal<'a when 'a : equality> private (valueProvider : IObservable<'a>, initialValue) =
+    // This will not be null when accessed, since an ObservableToSignal can only be created
+    // via Create, which initializes dependencies.
     let mutable dependencies:IDependencyManager<'a> = null
     let mutable lastValue = initialValue
 

--- a/src/Gjallarhorn/CoreTypes.fs
+++ b/src/Gjallarhorn/CoreTypes.fs
@@ -266,8 +266,10 @@ type internal ObservableToSignal<'a when 'a : equality> private (valueProvider :
 
     /// Default implementations work off single set of dependenices
     member __.HasDependencies with get() = dependencies.HasDependencies
-    member private _.SetDependencies(deps:IDependencyManager<'a>) = dependencies <- deps
-    member private _.SetWeakSubscription(subs:IDisposable)= weakSubscription <- subs
+
+    member private _.Init(deps:IDependencyManager<'a>, subs:IDisposable) =
+        dependencies <- deps
+        weakSubscription <- subs
 
     override this.Finalize() =
         (this :> IDisposable).Dispose()        
@@ -298,8 +300,7 @@ type internal ObservableToSignal<'a when 'a : equality> private (valueProvider :
             GC.SuppressFinalize this
     static member Create<'a when 'a : equality>(valueProvider : IObservable<'a>, initialValue) =
         let ots = new ObservableToSignal<'a>(valueProvider, initialValue)
-        ots.SetDependencies(Dependencies.create [| |] ots)
-        ots.SetWeakSubscription(subscribeWeak ots valueProvider)
+        ots.Init(Dependencies.create [| |] ots, subscribeWeak ots valueProvider)
         ots
 
 /// Construct using the Create method

--- a/src/Gjallarhorn/Mutable.fs
+++ b/src/Gjallarhorn/Mutable.fs
@@ -11,7 +11,7 @@ module Mutable =
 
     /// Create a threadsafe mutable variable wrapping an initial value
     let createThreadsafe<'a when 'a : not struct> (value : 'a) = 
-        new AtomicMutable<'a>(value) :> IAtomicMutatable<'a>
+        AtomicMutable.Create<'a>(value) :> IAtomicMutatable<'a>
 
     /// Create an asynchronous mutable variable wrapping an initial value
     let createAsync (value : 'a) = 

--- a/src/Gjallarhorn/Signal.fs
+++ b/src/Gjallarhorn/Signal.fs
@@ -40,7 +40,7 @@ module Signal =
     /// As such, it caches the "last valid" state of the signal locally.
     /// </remarks>
     let cache (provider : ISignal<'a>) = 
-        new CachedSignal<'a>(provider) :> ISignal<'a>
+        CachedSignal.Create<'a>(provider) :> ISignal<'a>
 
     module Subscription =
         /// Create a subscription to the changes of a signal which calls the provided function upon each change
@@ -87,7 +87,7 @@ module Signal =
 
     /// Create a signal from an observable.  As an ISignal always provides a value, the initial value to use upon creation is required.    
     let fromObservable initialValue (observable : IObservable<'a>) =
-        new ObservableToSignal<'a>(observable, initialValue) :> ISignal<'a> 
+        ObservableToSignal.Create<'a>(observable, initialValue) :> ISignal<'a> 
         
     /// Gets the current value associated with the signal
     let get (signal : ISignal<'a>) = 
@@ -104,12 +104,12 @@ module Signal =
 
     /// Transforms a signal value asynchronously by using a specified mapping function.
     let mapAsync<'a,'b when 'b : equality> (mapping : 'a -> Async<'b>) initialValue (provider : ISignal<'a>) =
-        let signal = new AsyncMappingSignal<'a,'b>(provider,initialValue, None, mapping)
+        let signal = AsyncMappingSignal.Create<'a,'b>(provider,initialValue, None, mapping)
         signal :> ISignal<'b>
 
     /// Transforms a signal value asynchronously by using a specified mapping function. Execution status is reported through the specified IdleTracker
     let mapAsyncTracked (mapping : 'a -> Async<'b>) initialValue tracker (provider : ISignal<'a>) =
-        let signal = new AsyncMappingSignal<'a,'b>(provider, initialValue, Some(tracker), mapping)
+        let signal = AsyncMappingSignal.Create<'a,'b>(provider, initialValue, Some(tracker), mapping)
         signal :> ISignal<'b>
         
     /// Combines two signals using a specified mapping function

--- a/src/Gjallarhorn/Signal.fs
+++ b/src/Gjallarhorn/Signal.fs
@@ -99,7 +99,7 @@ module Signal =
 
     /// Transforms a signal value by using a specified mapping function.
     let map (mapping : 'a -> 'b)  (provider : ISignal<'a>) = 
-        let signal = new MappingSignal<'a, 'b>(provider, mapping, false)
+        let signal = MappingSignal.Create<'a, 'b>(provider, mapping, false)
         signal :> ISignal<'b>
 
     /// Transforms a signal value asynchronously by using a specified mapping function.
@@ -270,7 +270,7 @@ module Signal =
     let observeOn ctx (signal : ISignal<'a>) =
         ObserveOnSignal.Create<'a>(signal, ctx) :> ISignal<'a>
                 
-    type internal ValidatorMappingSignal<'a,'b when 'a : equality>(validator : ValidationCollector<'a> -> ValidationCollector<'b>, valueProvider : ISignal<'a>) as self =
+    type internal ValidatorMappingSignal<'a,'b when 'a : equality> private (validator : ValidationCollector<'a> -> ValidationCollector<'b>, valueProvider : ISignal<'a>) as self =
         inherit SignalBase<'b option>()
         let validationDeps = Dependencies.create [| valueProvider |] (constant ValidationResult.Valid)
 
@@ -362,4 +362,4 @@ module Signal =
     /// Validates a signal with a validation chain
     let validate<'a,'b when 'a : equality> (validator : ValidationCollector<'a> -> ValidationCollector<'b>) (signal : ISignal<'a>) =
         // TODO: Should we pass through defaults?
-        new ValidatorMappingSignal<'a,'b>(validator, signal) :> IValidatedSignal<'a, 'b>    
+        ValidatorMappingSignal.Create<'a,'b>(validator, signal) :> IValidatedSignal<'a, 'b>    

--- a/tests/Gjallarhorn.Linq.Tests/SignalLinq.cs
+++ b/tests/Gjallarhorn.Linq.Tests/SignalLinq.cs
@@ -154,7 +154,7 @@ namespace Gjallarhorn.Linq.Tests
         [Test]
         public async Task SelectAsyncTracksProperly()
         {
-            var tracker = new IdleTracker(System.Threading.SynchronizationContext.Current);
+            var tracker = IdleTracker.Create(SynchronizationContext.Current);
 
             var value = Mutable.Create(0);
 


### PR DESCRIPTION
Is this any better @ReedCopsey ?

SignalBase is still there and I haven't done anything with types using validation.

The methods is sound unlike the last one. I reduced usage of options and should add comments explaining why NREs won't happen.

If you'd prefer not to merge we can work off a fork. I think this issue will be much easier to fix than to reproduce.

SignalBase is an abstract class and will need more work. There are 10 classes inheriting from it.

Fixes https://github.com/ReedCopsey/Gjallarhorn/issues/65